### PR TITLE
prefix parsing cmds with 'command'

### DIFF
--- a/gen_docker_fish_completions.py
+++ b/gen_docker_fish_completions.py
@@ -113,20 +113,20 @@ end
 function __fish_print_docker_containers --description 'Print a list of docker containers' -a select
     switch $select
         case running
-            docker ps -a --no-trunc | awk 'NR>1' | awk 'BEGIN {FS="  +"}; $5 ~ "^Up" {print $1 "\\n" $(NF-1)}' | tr ',' '\\n'
+            docker ps -a --no-trunc | command awk 'NR>1' | command awk 'BEGIN {FS="  +"}; $5 ~ "^Up" {print $1 "\\n" $(NF-1)}' | tr ',' '\\n'
         case stopped
-            docker ps -a --no-trunc | awk 'NR>1' | awk 'BEGIN {FS="  +"}; $5 ~ "^Exit" {print $1 "\\n" $(NF-1)}' | tr ',' '\\n'
+            docker ps -a --no-trunc | command awk 'NR>1' | command awk 'BEGIN {FS="  +"}; $5 ~ "^Exit" {print $1 "\\n" $(NF-1)}' | tr ',' '\\n'
         case all
-            docker ps -a --no-trunc | awk 'NR>1' | awk 'BEGIN {FS="  +"}; {print $1 "\\n" $(NF-1)}' | tr ',' '\\n'
+            docker ps -a --no-trunc | command awk 'NR>1' | command awk 'BEGIN {FS="  +"}; {print $1 "\\n" $(NF-1)}' | tr ',' '\\n'
     end
 end
 
 function __fish_print_docker_images --description 'Print a list of docker images'
-    docker images | awk 'NR>1' | grep -v '<none>' | awk '{print $1":"$2}'
+    docker images | command awk 'NR>1' | command grep -v '<none>' | command awk '{print $1":"$2}'
 end
 
 function __fish_print_docker_repositories --description 'Print a list of docker repositories'
-    docker images | awk 'NR>1' | grep -v '<none>' | awk '{print $1}' | sort | uniq
+    docker images | command awk 'NR>1' | command grep -v '<none>' | command awk '{print $1}' | command sort | command uniq
 end
 """
 


### PR DESCRIPTION
We don't want to resolv aliases for parsing command. (for instance `alias grep=grep -n`). However, we do want to resolv the alias for `docker` itself in case someone has an alias like `docker -H tcp://localhost:4243`.
