### PR TITLE
Alter __fish_print_docker_images to include unnamed images.

### DIFF
--- a/docker.fish
+++ b/docker.fish
@@ -35,7 +35,7 @@ function __fish_print_docker_containers --description 'Print a list of docker co
 end
 
 function __fish_print_docker_images --description 'Print a list of docker images'
-    docker images | command awk 'NR>1' | command grep -v '<none>' | command awk '{print $1":"$2}'
+    docker images | command awk 'NR>1' | command awk '{print $1":"$2"~"$3}' | command sed 's/^<none>:<none>~\(.*\)$/\1\tUnnamed Image/; s/~.*$//'
 end
 
 function __fish_print_docker_repositories --description 'Print a list of docker repositories'

--- a/gen_docker_fish_completions.py
+++ b/gen_docker_fish_completions.py
@@ -135,7 +135,7 @@ function __fish_print_docker_containers --description 'Print a list of docker co
 end
 
 function __fish_print_docker_images --description 'Print a list of docker images'
-    docker images | command awk 'NR>1' | command grep -v '<none>' | command awk '{print $1":"$2}'
+    docker images | command awk 'NR>1' | command awk '{print $1":"$2"~"$3}' | command sed 's/^<none>:<none>~\\(.*\\)$/\\1\\tUnnamed Image/; s/~.*$//'
 end
 
 function __fish_print_docker_repositories --description 'Print a list of docker repositories'


### PR DESCRIPTION
I don't know enough about Python string escaping to be certain that the
addition to gen_docker_fish_completions.py is correct. Would want that
reviewed to ensure it correctly generates the corresponding line in
docker.fish.